### PR TITLE
StorageCluster Support

### DIFF
--- a/examples/nfs/cluster.yaml
+++ b/examples/nfs/cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.coreos.com/v1alpha1
+kind: StorageCluster
+metadata:
+    name: nfs1
+spec:
+    type: nfs
+    storageNodes:
+        - nodeSelector:
+              kubernetes.io/hostname: ip-10-0-0-169.us-west-2.compute.internal
+          directories:
+              - /export

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 01c88fd0fe4722e0a0d60273c1ec9943b49f4b642e0c85cb914a0e1d8badf669
-updated: 2016-12-15T11:10:53.258699511-05:00
+hash: 2a889ab9e5ff02f8c9b4d7b5d479b3cbaa0501c241ce091a7dd544a7101f752f
+updated: 2016-12-28T17:41:53.314076813-05:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -19,6 +19,8 @@ imports:
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
+  - capnslog
+  - dlopen
   - health
   - httputil
   - timeutil
@@ -26,22 +28,51 @@ imports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
   version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
   - digest
   - reference
+- name: github.com/docker/engine-api
+  version: dea108d3aa0c67d7162a3fd8aa65f38a430019fd
+  subpackages:
+  - client
+  - client/transport
+  - client/transport/cancellable
+  - types
+  - types/blkiodev
+  - types/container
+  - types/filters
+  - types/network
+  - types/reference
+  - types/registry
+  - types/strslice
+  - types/time
+  - types/versions
+- name: github.com/docker/go-connections
+  version: f549a9393d05688dff0992ef3efd8bbe6c628aeb
+  subpackages:
+  - nat
+  - sockets
+  - tlsconfig
+- name: github.com/docker/go-units
+  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
 - name: github.com/emicklei/go-restful
   version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
   subpackages:
   - log
   - swagger
+- name: github.com/exponent-io/jsonpath
+  version: d6023ce2651d8eafb5c75bb0c7167536102ec9f5
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-kit/kit
-  version: f66b0e13579bfc5a48b9e2a94b1209c107ea1f41
+  version: 905b60253dbac4a14625ce52217ede00d3a3aca7
   subpackages:
   - log
+  - log/levels
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-openapi/jsonpointer
@@ -57,16 +88,46 @@ imports:
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
+  - gogoproto
+  - plugin/compare
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
   - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/grpc
+  - protoc-gen-gogo/plugin
   - sortkeys
+  - vanity
+  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
+  - jsonpb
   - proto
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
@@ -85,21 +146,32 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/cobra
+  version: f62e98d28ab7ad31d707ba837a966378465c7b57
+  subpackages:
+  - doc
 - name: github.com/spf13/pflag
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
+  - codec/codecgen
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
   - context/ctxhttp
+  - html
+  - html/atom
   - http2
   - http2/hpack
   - idna
+  - internal/timeseries
   - lex/httplex
+  - proxy
+  - trace
+  - websocket
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
@@ -136,29 +208,32 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
-- name: k8s.io/client-go
-  version: 243d8a9cb66a51ad8676157f79e71033b4014a2a
+- name: k8s.io/kubernetes
+  version: 82450d03cb057bab0950214ef122b67c83fb11df
   subpackages:
-  - discovery
-  - kubernetes
-  - kubernetes/typed/apps/v1beta1
-  - kubernetes/typed/authentication/v1beta1
-  - kubernetes/typed/authorization/v1beta1
-  - kubernetes/typed/autoscaling/v1
-  - kubernetes/typed/batch/v1
-  - kubernetes/typed/batch/v2alpha1
-  - kubernetes/typed/certificates/v1alpha1
-  - kubernetes/typed/core/v1
-  - kubernetes/typed/extensions/v1beta1
-  - kubernetes/typed/policy/v1beta1
-  - kubernetes/typed/rbac/v1alpha1
-  - kubernetes/typed/storage/v1beta1
+  - federation/apis/federation
+  - federation/apis/federation/install
+  - federation/apis/federation/v1beta1
+  - federation/client/clientset_generated/federation_internalclientset
+  - federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion
   - pkg/api
+  - pkg/api/annotations
+  - pkg/api/endpoints
   - pkg/api/errors
+  - pkg/api/events
   - pkg/api/install
   - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/pod
   - pkg/api/resource
+  - pkg/api/service
+  - pkg/api/unversioned
+  - pkg/api/unversioned/validation
+  - pkg/api/util
   - pkg/api/v1
+  - pkg/api/validation
   - pkg/api/validation/path
   - pkg/apimachinery
   - pkg/apimachinery/announced
@@ -182,11 +257,12 @@ imports:
   - pkg/apis/certificates
   - pkg/apis/certificates/install
   - pkg/apis/certificates/v1alpha1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
+  - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
-  - pkg/apis/meta/v1
-  - pkg/apis/meta/v1/unstructured
   - pkg/apis/policy
   - pkg/apis/policy/install
   - pkg/apis/policy/v1beta1
@@ -195,42 +271,81 @@ imports:
   - pkg/apis/rbac/v1alpha1
   - pkg/apis/storage
   - pkg/apis/storage/install
+  - pkg/apis/storage/util
   - pkg/apis/storage/v1beta1
+  - pkg/auth/authenticator
   - pkg/auth/user
+  - pkg/capabilities
+  - pkg/client/cache
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
+  - pkg/client/metrics
+  - pkg/client/record
+  - pkg/client/restclient
+  - pkg/client/retry
+  - pkg/client/transport
+  - pkg/client/typed/discovery
+  - pkg/client/unversioned
+  - pkg/client/unversioned/clientcmd/api
+  - pkg/controller
+  - pkg/controller/deployment/util
   - pkg/conversion
   - pkg/conversion/queryparams
+  - pkg/credentialprovider
+  - pkg/fieldpath
   - pkg/fields
   - pkg/genericapiserver/openapi/common
+  - pkg/kubectl
+  - pkg/kubectl/resource
+  - pkg/kubelet/qos
+  - pkg/kubelet/types
   - pkg/labels
+  - pkg/master/ports
   - pkg/runtime
-  - pkg/runtime/schema
   - pkg/runtime/serializer
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
+  - pkg/security/apparmor
   - pkg/selection
-  - pkg/third_party/forked/golang/reflect
-  - pkg/third_party/forked/golang/template
+  - pkg/serviceaccount
   - pkg/types
   - pkg/util
   - pkg/util/cert
   - pkg/util/clock
+  - pkg/util/config
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/flowcontrol
   - pkg/util/framer
+  - pkg/util/hash
   - pkg/util/integer
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/jsonpath
   - pkg/util/labels
   - pkg/util/net
+  - pkg/util/net/sets
+  - pkg/util/node
   - pkg/util/parsers
+  - pkg/util/pod
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/slice
+  - pkg/util/strategicpatch
   - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
@@ -242,9 +357,7 @@ imports:
   - plugin/pkg/client/auth
   - plugin/pkg/client/auth/gcp
   - plugin/pkg/client/auth/oidc
-  - rest
-  - tools/cache
-  - tools/clientcmd/api
-  - tools/metrics
-  - transport
+  - third_party/forked/golang/json
+  - third_party/forked/golang/reflect
+  - third_party/forked/golang/template
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,20 +3,24 @@ import:
 - package: github.com/go-kit/kit
   subpackages:
   - log
-- package: k8s.io/client-go
+  - log/levels
+- package: k8s.io/kubernetes
+  version: v1.5.1
   subpackages:
-  - kubernetes
   - pkg/api
   - pkg/api/errors
+  - pkg/api/unversioned
   - pkg/api/v1
+  - pkg/apis/extensions
   - pkg/apis/extensions/v1beta1
-  - pkg/apis/meta/v1
+  - pkg/api/meta
+  - pkg/client/cache
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/restclient
+  - pkg/kubectl
   - pkg/labels
   - pkg/runtime
-  - pkg/runtime/schema
   - pkg/runtime/serializer
   - pkg/util/runtime
   - pkg/util/wait
   - pkg/watch
-  - rest
-  - tools/cache

--- a/pkg/client/storagecluster.go
+++ b/pkg/client/storagecluster.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/coreos-inc/quartermaster/pkg/spec"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+type StorageClusters struct {
+	t *Transport
+}
+
+func NewStorageClusters(c *restclient.RESTClient, namespace string) *StorageClusters {
+	return &StorageClusters{
+		t: NewTransport(c, namespace, "storageclusters"),
+	}
+}
+
+func (c *StorageClusters) Create(storageCluster *spec.StorageCluster) (result *spec.StorageCluster, err error) {
+	obj, err := c.t.Create(storageCluster, &spec.StorageCluster{})
+	return obj.(*spec.StorageCluster), err
+}
+
+func (c *StorageClusters) Update(storageCluster *spec.StorageCluster) (result *spec.StorageCluster, err error) {
+	obj, err := c.t.Update(storageCluster, storageCluster.GetName(), &spec.StorageCluster{})
+	return obj.(*spec.StorageCluster), err
+}
+
+func (c *StorageClusters) Delete(name string, options *api.DeleteOptions) error {
+	return c.t.Delete(name, options)
+}
+
+func (c *StorageClusters) Get(name string) (result *spec.StorageCluster, err error) {
+	obj, err := c.t.Get(name, &spec.StorageCluster{})
+	return obj.(*spec.StorageCluster), err
+}
+
+func (c *StorageClusters) List(opts api.ListOptions) (result *spec.StorageClusterList, err error) {
+	obj, err := c.t.List(&spec.StorageClusterList{})
+	return obj.(*spec.StorageClusterList), err
+}

--- a/pkg/client/storagenode.go
+++ b/pkg/client/storagenode.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/coreos-inc/quartermaster/pkg/spec"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+type StorageNodes struct {
+	t *Transport
+}
+
+func NewStorageNodes(c *restclient.RESTClient, namespace string) *StorageNodes {
+	return &StorageNodes{
+		t: NewTransport(c, namespace, "storagenodes"),
+	}
+}
+
+func (c *StorageNodes) Create(storageNode *spec.StorageNode) (result *spec.StorageNode, err error) {
+	obj, err := c.t.Create(storageNode, &spec.StorageNode{})
+	return obj.(*spec.StorageNode), err
+}
+
+func (c *StorageNodes) Update(storageNode *spec.StorageNode) (result *spec.StorageNode, err error) {
+	obj, err := c.t.Update(storageNode, storageNode.GetName(), &spec.StorageNode{})
+	return obj.(*spec.StorageNode), err
+}
+
+func (c *StorageNodes) Delete(name string, options *api.DeleteOptions) error {
+	return c.t.Delete(name, options)
+}
+
+func (c *StorageNodes) Get(name string) (result *spec.StorageNode, err error) {
+	obj, err := c.t.Get(name, &spec.StorageNode{})
+	return obj.(*spec.StorageNode), err
+}
+
+func (c *StorageNodes) List(opts api.ListOptions) (result *spec.StorageNodeList, err error) {
+	obj, err := c.t.List(&spec.StorageNodeList{})
+	return obj.(*spec.StorageNodeList), err
+}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -1,0 +1,135 @@
+// Copyright 2017 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+type Transport struct {
+	resource string
+	ns       string
+	client   *restclient.RESTClient
+}
+
+func NewTransport(c *restclient.RESTClient, namespace, resoure string) *Transport {
+	return &Transport{
+		client:   c,
+		ns:       namespace,
+		resource: resoure,
+	}
+}
+
+func (t *Transport) Create(in interface{}, resultObj interface{}) (result interface{}, err error) {
+	result = resultObj
+
+	req := t.client.Post().
+		Namespace(t.ns).
+		Resource(t.resource).
+		Body(in)
+
+	body, err := req.DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, result)
+	return
+}
+
+func (t *Transport) Update(in interface{},
+	name string,
+	resultObj interface{}) (result interface{}, err error) {
+
+	result = resultObj
+	req := t.client.Put().
+		Namespace(t.ns).
+		Resource(t.resource).
+		Name(name).
+		Body(in)
+
+	body, err := req.DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, result)
+	return
+}
+
+func (t *Transport) UpdateStatus(in interface{},
+	name string,
+	resultObj interface{}) (result interface{}, err error) {
+
+	result = resultObj
+	req := t.client.Put().
+		Namespace(t.ns).
+		Resource(t.resource).
+		Name(name).
+		SubResource("status").
+		Body(in)
+
+	body, err := req.DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, result)
+	return
+}
+
+func (t *Transport) Delete(name string, options *api.DeleteOptions) error {
+	return t.client.Delete().
+		Namespace(t.ns).
+		Resource(t.resource).
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+func (t *Transport) Get(name string, resultObj interface{}) (result interface{}, err error) {
+	result = resultObj
+	req := t.client.Get().
+		Namespace(t.ns).
+		Resource(t.resource).
+		Name(name)
+
+	body, err := req.DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, result)
+	return
+}
+
+func (t *Transport) List(resultObj interface{}) (result interface{}, err error) {
+	result = resultObj
+	r := t.client.Get().
+		Namespace(t.ns).
+		Resource(t.resource)
+
+	body, err := r.DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, result)
+	return
+}

--- a/pkg/operator/cluster_operator.go
+++ b/pkg/operator/cluster_operator.go
@@ -1,0 +1,208 @@
+// Copyright 2016 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	qmclient "github.com/coreos-inc/quartermaster/pkg/client"
+	"github.com/coreos-inc/quartermaster/pkg/spec"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/cache"
+)
+
+type StorageOperator interface {
+	Setup(stopc <-chan struct{}) error
+	HasSynced() bool
+}
+
+type StorageClusterOperator struct {
+	op  *Operator
+	inf cache.SharedIndexInformer
+}
+
+func NewStorageClusterOperator(op *Operator) StorageOperator {
+	return &StorageClusterOperator{
+		op: op, // this is a bad idea, but ok for PoC
+		inf: cache.NewSharedIndexInformer(
+			NewStorageClusterListWatch(op.rclient),
+			&spec.StorageCluster{}, resyncPeriod, cache.Indexers{}),
+	}
+}
+
+func (s *StorageClusterOperator) Setup(stopc <-chan struct{}) error {
+	s.inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(p interface{}) {
+			s.op.logger.Log("msg", "enqueueStorageCluster", "trigger", "storagecluster add")
+			s.add(p.(*spec.StorageCluster))
+		},
+		DeleteFunc: func(p interface{}) {
+			s.op.logger.Log("msg", "enqueueStorageCluster", "trigger", "storagecluster del")
+			s.delete(p.(*spec.StorageCluster))
+		},
+
+		// This needs to change to get old and new
+		UpdateFunc: func(old, new interface{}) {
+			s.op.logger.Log("msg", "enqueueStorageCluster", "trigger", "storagecluster update")
+			s.update(old.(*spec.StorageCluster), new.(*spec.StorageCluster))
+		},
+	})
+
+	go s.inf.Run(stopc)
+
+	return nil
+}
+
+func (s *StorageClusterOperator) HasSynced() bool {
+	return s.inf.HasSynced()
+}
+
+func (s *StorageClusterOperator) add(cs *spec.StorageCluster) error {
+	s.op.logger.Log("msg", "adding")
+
+	/*
+		// Defult stuff
+		condition := spec.StorageClusterCondition{}
+		condition.Message = "My message 0"
+		condition.Reason = "Zero"
+		condition.Type = spec.ClusterConditionOffline
+
+		sp.Status.Ready = false
+		sp.Status.Message = "This is a message"
+		sp.Status.Reason = "I have my reasons"
+		sp.Status.Conditions = []spec.StorageClusterCondition{
+			condition,
+		}
+
+	*/
+
+	// Set default values
+	cs.Status.Ready = false
+
+	// Call plugin
+	_, err := s.op.storage.AddCluster(cs)
+	if err != nil {
+		return s.op.logger.Log("err", err)
+	}
+
+	// Update cluster object
+	sclient := qmclient.NewStorageClusters(s.op.rclient, cs.Namespace)
+	cs, err = sclient.Update(cs)
+	if err != nil {
+		return s.op.logger.Log("err", err)
+	}
+
+	// Submit each node
+	s.submitNodesFor(cs)
+
+	return nil
+
+}
+
+func (s *StorageClusterOperator) update(
+	old *spec.StorageCluster,
+	new *spec.StorageCluster) error {
+	s.op.logger.Log("msg", "update")
+
+	if old.ResourceVersion == new.ResourceVersion {
+		s.op.logger.Log("msg", "same version")
+		return nil
+	}
+
+	s.op.logger.Log("msg", "update found")
+
+	// Call plugin
+	err := s.op.storage.UpdateCluster(old, new)
+	if err != nil {
+		return s.op.logger.Log("err", err)
+	}
+
+	return nil
+}
+
+func (s *StorageClusterOperator) delete(cs *spec.StorageCluster) error {
+	s.op.logger.Log("msg", "delete")
+
+	// Create client
+	ns_client := qmclient.NewStorageNodes(s.op.rclient, cs.GetNamespace())
+
+	// Get all storagenodes with the same label
+	list, err := ns_client.List(api.ListOptions{})
+	if err != nil {
+		return s.op.logger.Log("err", err)
+	}
+	s.op.logger.Log("nodes to delete", len(list.Items))
+
+	// Delete all nodes
+	for _, node := range list.Items {
+		if node.Spec.ClusterRef.Name == cs.GetName() {
+			err := ns_client.Delete(node.GetName(), nil)
+			if err != nil {
+				s.op.logger.Log("msg", "unable to delete", "node", node.GetName(), "err", err)
+			} else {
+				s.op.logger.Log("msg", "deleted", "node", node.GetName())
+			}
+		}
+	}
+
+	// Call plugin
+	err = s.op.storage.DeleteCluster(cs)
+	if err != nil {
+		return s.op.logger.Log("err", err)
+	}
+
+	return nil
+}
+
+func (s *StorageClusterOperator) submitNodesFor(cs *spec.StorageCluster) {
+	s.op.logger.Log("msg", "submitting nodes")
+
+	// Create client
+	ns_client := qmclient.NewStorageNodes(s.op.rclient, cs.Namespace)
+
+	// Create a reference object
+	clusterRef, err := api.GetReference(cs)
+	if err != nil {
+		s.op.logger.Log("err", err)
+		return
+	}
+
+	// Create nodes
+	for _, ns := range cs.Spec.StorageNodes {
+
+		// Setup StorageNode object
+		node := &spec.StorageNode{
+			TypeMeta: unversioned.TypeMeta{
+				Kind:       "StorageNode",
+				APIVersion: cs.APIVersion,
+			},
+			ObjectMeta: api.ObjectMeta{
+				GenerateName: cs.Name + "-",
+				Namespace:    cs.Namespace,
+				Labels:       cs.Labels,
+			},
+			Spec: ns,
+		}
+		node.Spec.ClusterRef = clusterRef
+
+		// Submit the node
+		result, err := ns_client.Create(node)
+		if err != nil {
+			s.op.logger.Log("msg", "unable to create a storage node", "err", err)
+		} else {
+			s.op.logger.Log("msg", "created a storage node", "name", result.GetName())
+		}
+	}
+}

--- a/pkg/operator/k8sutil.go
+++ b/pkg/operator/k8sutil.go
@@ -19,22 +19,22 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/client-go/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/util/wait"
-	"k8s.io/client-go/rest"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 // WaitForTPRReady waits for a third party resource to be available
 // for use.
-func WaitForTPRReady(restClient rest.Interface, tprGroup, tprVersion, tprName string) error {
+func WaitForTPRReady(restClient restclient.Interface, tprGroup, tprVersion, tprName string) error {
 	return wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
 		res := restClient.Get().AbsPath("apis", tprGroup, tprVersion, tprName).Do()
 		err := res.Error()
 		if err != nil {
 			// RESTClient returns *errors.StatusError for any status codes < 200 or > 206
 			// and http.Client.Do errors are returned directly.
-			if se, ok := err.(*errors.StatusError); ok {
+			if se, ok := err.(*apierrors.StatusError); ok {
 				if se.Status().Code == http.StatusNotFound {
 					return false, nil
 				}

--- a/pkg/operator/storage_handler.go
+++ b/pkg/operator/storage_handler.go
@@ -1,0 +1,107 @@
+// Copyright 2017 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"github.com/coreos-inc/quartermaster/pkg/spec"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+type StorageHandlerFuncs struct {
+	StorageHandler interface{}
+
+	AddClusterFunc    func(c *spec.StorageCluster) (*spec.StorageCluster, error)
+	UpdateClusterFunc func(old *spec.StorageCluster, new *spec.StorageCluster) error
+	DeleteClusterFunc func(c *spec.StorageCluster) error
+
+	MakeDeploymentFunc func(c *spec.StorageCluster,
+		n *spec.StorageNode,
+		old *extensions.Deployment) (*extensions.Deployment, error)
+	AddNodeFunc    func(c *spec.StorageCluster, n *spec.StorageNode) (*spec.StorageNode, error)
+	UpdateNodeFunc func(c *spec.StorageCluster, n *spec.StorageNode) (*spec.StorageNode, error)
+	DeleteNodeFunc func(c *spec.StorageCluster, n *spec.StorageNode) error
+
+	InitFunc      func() error
+	GetStatusFunc func(c *spec.StorageCluster) (*spec.StorageStatus, error)
+}
+
+func (s StorageHandlerFuncs) AddCluster(c *spec.StorageCluster) (*spec.StorageCluster, error) {
+	if s.AddClusterFunc != nil {
+		return s.AddClusterFunc(c)
+	}
+	return nil, nil
+}
+
+func (s StorageHandlerFuncs) UpdateCluster(old *spec.StorageCluster,
+	new *spec.StorageCluster) error {
+	if s.UpdateClusterFunc != nil {
+		return s.UpdateClusterFunc(old, new)
+	}
+	return nil
+}
+
+func (s StorageHandlerFuncs) DeleteCluster(c *spec.StorageCluster) error {
+	if s.DeleteClusterFunc != nil {
+		return s.DeleteClusterFunc(c)
+	}
+	return nil
+}
+
+func (s StorageHandlerFuncs) MakeDeployment(c *spec.StorageCluster,
+	n *spec.StorageNode,
+	old *extensions.Deployment) (*extensions.Deployment, error) {
+	if s.MakeDeploymentFunc != nil {
+		return s.MakeDeploymentFunc(c, n, old)
+	}
+	return nil, nil
+}
+
+func (s StorageHandlerFuncs) AddNode(c *spec.StorageCluster,
+	n *spec.StorageNode) (*spec.StorageNode, error) {
+	if s.AddNodeFunc != nil {
+		return s.AddNodeFunc(c, n)
+	}
+	return nil, nil
+}
+
+func (s StorageHandlerFuncs) UpdateNode(c *spec.StorageCluster,
+	n *spec.StorageNode) (*spec.StorageNode, error) {
+	if s.UpdateNodeFunc != nil {
+		return s.UpdateNodeFunc(c, n)
+	}
+	return nil, nil
+}
+
+func (s StorageHandlerFuncs) DeleteNode(c *spec.StorageCluster,
+	n *spec.StorageNode) error {
+	if s.DeleteNodeFunc != nil {
+		return s.DeleteNodeFunc(c, n)
+	}
+	return nil
+}
+
+func (s StorageHandlerFuncs) Init() error {
+	if s.InitFunc != nil {
+		return s.InitFunc()
+	}
+	return nil
+}
+
+func (s StorageHandlerFuncs) GetStatus(c *spec.StorageCluster) (*spec.StorageStatus, error) {
+	if s.GetStatusFunc != nil {
+		return s.GetStatusFunc(c)
+	}
+	return nil, nil
+}

--- a/pkg/operator/storage_type.go
+++ b/pkg/operator/storage_type.go
@@ -16,15 +16,31 @@ package operator
 
 import (
 	"github.com/coreos-inc/quartermaster/pkg/spec"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
-type StorageType interface {
-	Init() error
-	MakeDaemonSet(s *spec.StorageNode, old *v1beta1.DaemonSet) (*v1beta1.DaemonSet, error)
-	AddNode(s *spec.StorageNode) error
-	GetStatus(s *spec.StorageNode) (*spec.StorageStatus, error)
+type StorageClusterInterface interface {
+	AddCluster(c *spec.StorageCluster) (*spec.StorageCluster, error)
+	UpdateCluster(old *spec.StorageCluster, new *spec.StorageCluster) error
+	DeleteCluster(c *spec.StorageCluster) error
 }
 
-type StorageTypeNewFunc func(*kubernetes.Clientset) (StorageType, error)
+type StorageNodeInterface interface {
+	MakeDeployment(c *spec.StorageCluster,
+		s *spec.StorageNode,
+		old *extensions.Deployment) (*extensions.Deployment, error)
+	AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error)
+	UpdateNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error)
+	DeleteNode(c *spec.StorageCluster, s *spec.StorageNode) error
+}
+
+type StorageType interface {
+	StorageClusterInterface
+	StorageNodeInterface
+
+	Init() error
+	GetStatus(c *spec.StorageCluster) (*spec.StorageStatus, error)
+}
+
+type StorageTypeNewFunc func(*clientset.Clientset) (StorageType, error)

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -1,0 +1,100 @@
+// Copyright 2016 The quartermaster Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+const (
+	TPRGroup   = "storage.coreos.com"
+	TPRVersion = "v1alpha1"
+
+	TPRStorageNodeKind    = "storagenode"
+	TPRStorageStatusKind  = "storagestatus"
+	TPRStorageClusterKind = "storagecluster"
+
+	PluralTPRStorageNodeKind    = TPRStorageNodeKind + "s"
+	PluralTPRStorageStatusKind  = TPRStorageStatusKind + "es"
+	PluralTPRStorageClusterKind = TPRStorageClusterKind + "s"
+
+	tprStorageNode    = "storage-node." + TPRGroup
+	tprStorageStatus  = "storage-status." + TPRGroup
+	tprStorageCluster = "storage-cluster." + TPRGroup
+)
+
+var (
+	tprPluralList = []string{PluralTPRStorageClusterKind,
+		PluralTPRStorageNodeKind,
+		PluralTPRStorageStatusKind}
+)
+
+func (c *Operator) createTPRs() error {
+	tprs := []*extensions.ThirdPartyResource{
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name: tprStorageStatus,
+			},
+			Versions: []extensions.APIVersion{
+				{Name: TPRVersion},
+			},
+			Description: "Status reports from Quartermaster managed storage",
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name: tprStorageNode,
+			},
+			Versions: []extensions.APIVersion{
+				{Name: TPRVersion},
+			},
+			Description: "Managed storage nodes via Quartermaster",
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name: tprStorageCluster,
+			},
+			Versions: []extensions.APIVersion{
+				{Name: TPRVersion},
+			},
+			Description: "Managed storage clusters via Quartermaster",
+		},
+	}
+	tprClient := c.kclient.Extensions().ThirdPartyResources()
+	for _, tpr := range tprs {
+		_, err := tprClient.Create(tpr)
+		if apierrors.IsAlreadyExists(err) {
+			c.logger.Log("msg", "TPR already registered", "tpr", tpr.Name)
+		} else if err != nil {
+			return err
+		} else {
+			c.logger.Log("msg", "TPR created", "tpr", tpr.Name)
+		}
+	}
+
+	// We have to wait for the TPRs to be ready. Otherwise the initial watch may fail.
+	for _, pluralTpr := range tprPluralList {
+		err := WaitForTPRReady(c.kclient.Core().RESTClient(),
+			TPRGroup,
+			TPRVersion,
+			pluralTpr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
StorageCluster enables the user to insert a single descriptor
which defines all the storage nodes.  QuarterMaster is then
notified on the new added StorageCluster object and then
creates a StorageNode for each node in the StorageCluster.

Signed-off-by: Luis Pabón <luis.pabon@coreos.com>