### PR TITLE
Rename Authors to Maintainers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,0 @@
-luis.pabon@coreos.com
-lpabon@gmail.com
-barak.michener@coreos.com

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,2 @@
+Barak Michener <barak.michener@coreos.com> pkg: *
+Luis Pabón <luis.pabon@coreos.com, lpabon@gmail.com> pkg: *


### PR DESCRIPTION
Let's follower CoreOS project conventions:

https://github.com/coreos/rkt/blob/master/MAINTAINERS
https://github.com/coreos/etcd/blob/master/MAINTAINERS