### PR TITLE
GlusterFS Cluster Up

### DIFF
--- a/examples/glusterfs/gluster-pvc.yaml
+++ b/examples/glusterfs/gluster-pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: myvol
+  annotations:
+    volume.beta.kubernetes.io/storage-class: gluster.qm.default
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 34Gi

--- a/pkg/storage/glusterfs/glusterfs_test.go
+++ b/pkg/storage/glusterfs/glusterfs_test.go
@@ -86,6 +86,12 @@ func TestGlusterFSAddClusterNoHeketi(t *testing.T) {
 		},
 	}
 
+	// Set to garbage
+	defer tests.Patch(&heketiAddressFn,
+		func(namespace string) (string, error) {
+			return "http://nothing:12345", nil
+		}).Restore()
+
 	// Don't wait for deployemnt
 	defer tests.Patch(&waitForDeploymentFn,
 		func(client clientset.Interface, namespace, name string, available int32) error {


### PR DESCRIPTION
This change enables the cluster to go Ready when at least
three nodes are added to the cluster.  It the creates a StorageClass
per Heketi instance, therefore there is only one StorageClass per
namespace, no matter how many GlusterFS clusters there are.  This
is becaues Heketi takes care of managing all GlusterFS clusters
as one.

Signed-off-by: Luis Pabón <luis.pabon@coreos.com>