### PR TITLE
storage: add doc for StorageClusterInterface

### DIFF
--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -16,14 +16,26 @@ package operator
 
 import (
 	"github.com/coreos-inc/quartermaster/pkg/spec"
+
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
 type StorageClusterInterface interface {
+	// AddCluster adds a new storage cluster.
+	// AddCluster will be called by Quartermaster controller when a new
+	// storage cluster `c` is created as a StorageCluster TPR.
 	AddCluster(c *spec.StorageCluster) (*spec.StorageCluster, error)
-	UpdateCluster(old *spec.StorageCluster, new *spec.StorageCluster) error
+
+	// UpdateCluster updates the cluster.
+	// UpdateCluster will be called by Quartermaster controller when an existing
+	// storage cluster `oldc` is updated to `newc`.
+	UpdateCluster(oldc *spec.StorageCluster, newc *spec.StorageCluster) error
+
+	// DeleteCluster deletes the cluster.
+	// DeleteCluster will be called by Quartermaster controller when the storage cluster
+	// `c` is deleted.
 	DeleteCluster(c *spec.StorageCluster) error
 }
 


### PR DESCRIPTION
We probably should rename `StorageClusterInterface` to `StorageCluster`. Interface suffix is uncommon in go.