### PR TITLE
Remove StorageCluster from StorageNode APIs

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -291,9 +291,6 @@ func (c *Operator) updateDeployment(oldo, curo interface{}) {
 }
 
 func (c *Operator) reconcile(s *spec.StorageNode) error {
-	// TODO(lpabon): Remove this.
-	clusterSpec := &spec.StorageCluster{}
-
 	key, err := keyFunc(s)
 	if err != nil {
 		c.logger.Log("err", err)
@@ -368,7 +365,7 @@ func (c *Operator) reconcile(s *spec.StorageNode) error {
 	if !exists {
 
 		// Get a deployment from plugin
-		ds, err := storage.MakeDeployment(clusterSpec, s, nil)
+		ds, err := storage.MakeDeployment(s, nil)
 		if err != nil {
 			c.logger.Log("err", err)
 			return err
@@ -389,7 +386,7 @@ func (c *Operator) reconcile(s *spec.StorageNode) error {
 		}
 
 		// Add node
-		updated, err := storage.AddNode(clusterSpec, s)
+		updated, err := storage.AddNode(s)
 		if err != nil {
 			c.logger.Log("err", err)
 			return err
@@ -406,9 +403,7 @@ func (c *Operator) reconcile(s *spec.StorageNode) error {
 		}
 	} else {
 		// Update
-		ds, err := storage.MakeDeployment(clusterSpec,
-			s,
-			obj.(*extensions.Deployment))
+		ds, err := storage.MakeDeployment(s, obj.(*extensions.Deployment))
 		if err != nil {
 			c.logger.Log("err", err)
 			return err
@@ -422,7 +417,7 @@ func (c *Operator) reconcile(s *spec.StorageNode) error {
 		}
 
 		// Update Node
-		_, err = storage.UpdateNode(clusterSpec, s)
+		_, err = storage.UpdateNode(s)
 		if err != nil {
 			c.logger.Log("err", err)
 			return err

--- a/pkg/storage/glusterfs/glusterfs.go
+++ b/pkg/storage/glusterfs/glusterfs.go
@@ -133,8 +133,7 @@ func (st *GlusterStorage) DeleteCluster(c *spec.StorageCluster) error {
 	return nil
 }
 
-func (st *GlusterStorage) MakeDeployment(c *spec.StorageCluster,
-	s *spec.StorageNode,
+func (st *GlusterStorage) MakeDeployment(s *spec.StorageNode,
 	old *extensions.Deployment) (*extensions.Deployment, error) {
 
 	// TODO(lpabon): Make this required
@@ -166,7 +165,7 @@ func (st *GlusterStorage) MakeDeployment(c *spec.StorageCluster,
 	return deployment, nil
 }
 
-func (st *GlusterStorage) AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *GlusterStorage) AddNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 
 	// Get cluster client
 	clusters := qmclient.NewStorageClusters(st.qm, s.GetNamespace())
@@ -296,7 +295,7 @@ func (st *GlusterStorage) AddNode(c *spec.StorageCluster, s *spec.StorageNode) (
 	return s, nil
 }
 
-func (st *GlusterStorage) UpdateNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *GlusterStorage) UpdateNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Debug("update node storagenode %v", s.Name)
 	return nil, nil
 }

--- a/pkg/storage/glusterfs/glusterfs_test.go
+++ b/pkg/storage/glusterfs/glusterfs_test.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"testing"
 
-	//qmclient "github.com/coreos-inc/quartermaster/pkg/client"
 	"github.com/coreos-inc/quartermaster/pkg/operator"
 	"github.com/coreos-inc/quartermaster/pkg/spec"
 	qmstorage "github.com/coreos-inc/quartermaster/pkg/storage"
@@ -242,7 +241,7 @@ func TestGlusterFSMakeDeployment(t *testing.T) {
 
 	// Get a deployment.No old deployment
 	// image is provided
-	deploy, err := op.MakeDeployment(&spec.StorageCluster{}, n, nil)
+	deploy, err := op.MakeDeployment(n, nil)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, deploy != nil)
 
@@ -358,7 +357,7 @@ func TestGlusterFSAddNewNodeWithHeketi(t *testing.T) {
 	tests.Assert(t, err == nil)
 
 	// Add the node without initializing the cluster
-	retn, err := op.AddNode(c, n)
+	retn, err := op.AddNode(n)
 	tests.Assert(t, err != nil)
 	tests.Assert(t, retn == nil)
 
@@ -370,7 +369,7 @@ func TestGlusterFSAddNewNodeWithHeketi(t *testing.T) {
 	tests.Assert(t, len(retc.Spec.GlusterFS.Cluster) != 0)
 
 	// Add node .. missing glusterfs information
-	retn, err = op.AddNode(c, n)
+	retn, err = op.AddNode(n)
 	tests.Assert(t, err != nil)
 	tests.Assert(t, retn == nil)
 
@@ -379,7 +378,7 @@ func TestGlusterFSAddNewNodeWithHeketi(t *testing.T) {
 		Zone: 1,
 	}
 
-	retn, err = op.AddNode(c, n)
+	retn, err = op.AddNode(n)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, retn != nil)
 
@@ -493,7 +492,7 @@ func TestGlusterFSAddNewNodeWithDevices(t *testing.T) {
 	tests.Assert(t, retc != nil)
 
 	// Add node
-	retn, err := op.AddNode(c, n)
+	retn, err := op.AddNode(n)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, retn != nil)
 
@@ -624,7 +623,7 @@ func TestGlusterFSAddNewNodeAddOneDevice(t *testing.T) {
 	tests.Assert(t, retc != nil)
 
 	// Add node
-	retn, err := op.AddNode(c, n)
+	retn, err := op.AddNode(n)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, retn != nil)
 
@@ -650,7 +649,7 @@ func TestGlusterFSAddNewNodeAddOneDevice(t *testing.T) {
 	retn.Spec.Devices = append(retn.Spec.Devices, "/dev/added")
 
 	// Add new device to node
-	retn, err = op.AddNode(c, retn)
+	retn, err = op.AddNode(retn)
 	tests.Assert(t, err == nil)
 	tests.Assert(t, retn != nil)
 

--- a/pkg/storage/handler.go
+++ b/pkg/storage/handler.go
@@ -27,12 +27,10 @@ type StorageHandlerFuncs struct {
 	UpdateClusterFunc func(old *spec.StorageCluster, new *spec.StorageCluster) error
 	DeleteClusterFunc func(c *spec.StorageCluster) error
 
-	MakeDeploymentFunc func(c *spec.StorageCluster,
-		n *spec.StorageNode,
-		old *extensions.Deployment) (*extensions.Deployment, error)
-	AddNodeFunc    func(c *spec.StorageCluster, n *spec.StorageNode) (*spec.StorageNode, error)
-	UpdateNodeFunc func(c *spec.StorageCluster, n *spec.StorageNode) (*spec.StorageNode, error)
-	DeleteNodeFunc func(n *spec.StorageNode) error
+	MakeDeploymentFunc func(n *spec.StorageNode, old *extensions.Deployment) (*extensions.Deployment, error)
+	AddNodeFunc        func(n *spec.StorageNode) (*spec.StorageNode, error)
+	UpdateNodeFunc     func(n *spec.StorageNode) (*spec.StorageNode, error)
+	DeleteNodeFunc     func(n *spec.StorageNode) error
 
 	InitFunc      func() error
 	GetStatusFunc func(c *spec.StorageCluster) (*spec.StorageStatus, error)
@@ -61,27 +59,24 @@ func (s StorageHandlerFuncs) DeleteCluster(c *spec.StorageCluster) error {
 	return nil
 }
 
-func (s StorageHandlerFuncs) MakeDeployment(c *spec.StorageCluster,
-	n *spec.StorageNode,
+func (s StorageHandlerFuncs) MakeDeployment(n *spec.StorageNode,
 	old *extensions.Deployment) (*extensions.Deployment, error) {
 	if s.MakeDeploymentFunc != nil {
-		return s.MakeDeploymentFunc(c, n, old)
+		return s.MakeDeploymentFunc(n, old)
 	}
 	return nil, nil
 }
 
-func (s StorageHandlerFuncs) AddNode(c *spec.StorageCluster,
-	n *spec.StorageNode) (*spec.StorageNode, error) {
+func (s StorageHandlerFuncs) AddNode(n *spec.StorageNode) (*spec.StorageNode, error) {
 	if s.AddNodeFunc != nil {
-		return s.AddNodeFunc(c, n)
+		return s.AddNodeFunc(n)
 	}
 	return nil, nil
 }
 
-func (s StorageHandlerFuncs) UpdateNode(c *spec.StorageCluster,
-	n *spec.StorageNode) (*spec.StorageNode, error) {
+func (s StorageHandlerFuncs) UpdateNode(n *spec.StorageNode) (*spec.StorageNode, error) {
 	if s.UpdateNodeFunc != nil {
-		return s.UpdateNodeFunc(c, n)
+		return s.UpdateNodeFunc(n)
 	}
 	return nil, nil
 }

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -28,11 +28,9 @@ type StorageClusterInterface interface {
 }
 
 type StorageNodeInterface interface {
-	MakeDeployment(c *spec.StorageCluster,
-		s *spec.StorageNode,
-		old *extensions.Deployment) (*extensions.Deployment, error)
-	AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error)
-	UpdateNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error)
+	MakeDeployment(s *spec.StorageNode, old *extensions.Deployment) (*extensions.Deployment, error)
+	AddNode(s *spec.StorageNode) (*spec.StorageNode, error)
+	UpdateNode(s *spec.StorageNode) (*spec.StorageNode, error)
 	DeleteNode(s *spec.StorageNode) error
 }
 

--- a/pkg/storage/mock/mock.go
+++ b/pkg/storage/mock/mock.go
@@ -86,8 +86,7 @@ func (st *MockStorage) DeleteCluster(c *spec.StorageCluster) error {
 	return nil
 }
 
-func (st *MockStorage) MakeDeployment(c *spec.StorageCluster,
-	s *spec.StorageNode,
+func (st *MockStorage) MakeDeployment(s *spec.StorageNode,
 	old *extensions.Deployment) (*extensions.Deployment, error) {
 	logger.Debug().Log("msg", "make deployment", "node", s.Name)
 
@@ -166,12 +165,12 @@ func (st *MockStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Depl
 	return spec, nil
 }
 
-func (st *MockStorage) AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *MockStorage) AddNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Debug().Log("msg", "add node", "storagenode", s.Name)
 	return nil, nil
 }
 
-func (st *MockStorage) UpdateNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *MockStorage) UpdateNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Debug().Log("msg", "update node", "storagenode", s.Name)
 	return nil, nil
 }

--- a/pkg/storage/nfs/nfs.go
+++ b/pkg/storage/nfs/nfs.go
@@ -55,8 +55,7 @@ func (st *NfsStorage) Init() error {
 	return nil
 }
 
-func (st *NfsStorage) MakeDeployment(c *spec.StorageCluster,
-	s *spec.StorageNode,
+func (st *NfsStorage) MakeDeployment(s *spec.StorageNode,
 	old *extensions.Deployment) (*extensions.Deployment, error) {
 
 	if s.Spec.Image == "" {
@@ -168,7 +167,7 @@ func (st *NfsStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Deplo
 	return spec, nil
 }
 
-func (st *NfsStorage) AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *NfsStorage) AddNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Debug().Log("msg", "add node", "storagenode", s.Name)
 
 	// Update status of node and cluster
@@ -194,7 +193,7 @@ func (st *NfsStorage) AddNode(c *spec.StorageCluster, s *spec.StorageNode) (*spe
 	return s, nil
 }
 
-func (st *NfsStorage) UpdateNode(c *spec.StorageCluster, s *spec.StorageNode) (*spec.StorageNode, error) {
+func (st *NfsStorage) UpdateNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Debug().Log("msg", "update node", "storagenode", s.Name)
 	return nil, nil
 }


### PR DESCRIPTION
Leave it up to the driver to get StorageCluster referenced by the
StorageNode if it needs to. An API will be added later to
StorageNode to facilitate this request for drivers.

Closes: #40

Signed-off-by: Luis Pabón <luis.pabon@coreos.com>