### PR TITLE
Track StorageNode state changes better

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -209,6 +209,7 @@ type StorageClusterStatus struct {
 
 type StorageNodeStatus struct {
 	StatusInfo
+	Added      bool                   `json:"added,omitempty"`
 	Conditions []StorageNodeCondition `json:"conditions,omitempty"`
 	PodName    string                 `json:"podName,omitempty"`
 	NodeName   string                 `json:"nodeName,omitempty"`


### PR DESCRIPTION
Instead of using a goroutine which caused issues when adding
nodes, use the events from deployments to determine when to add
a node.