### PR TITLE
multi-node swift driver

### DIFF
--- a/examples/swift/cluster.yaml
+++ b/examples/swift/cluster.yaml
@@ -5,10 +5,26 @@ metadata:
 spec:
     type: swift
     storageNodes:
-        - nodeName: minikube
+        - nodeName: node0
           storageNetwork:
             ips:
-              - 10.0.0.150
+              - 10.96.0.150
+          devices:
+              - vdb1
+              - vdc1
+              - vdd1
+        - nodeName: node1
+          storageNetwork:
+            ips:
+              - 10.96.0.151
+          devices:
+              - vdb1
+              - vdc1
+              - vdd1
+        - nodeName: node2
+          storageNetwork:
+            ips:
+              - 10.96.0.151
           devices:
               - vdb1
               - vdc1

--- a/examples/swift/cluster.yaml
+++ b/examples/swift/cluster.yaml
@@ -6,5 +6,10 @@ spec:
     type: swift
     storageNodes:
         - nodeName: minikube
-          directories:
-              - /export
+          storageNetwork:
+            ips:
+              - 10.0.0.150
+          devices:
+              - vdb1
+              - vdc1
+              - vdd1

--- a/pkg/storage/swift/README.md
+++ b/pkg/storage/swift/README.md
@@ -2,13 +2,15 @@
 
 **Status: Not for production, experimental only**
 
-This driver provides an example deployment of a Swift All in One cluster.
-The SAIO is configured with a one replica ring and can be used to test the Swift API.
+This driver provides an example of a Swift cluster deployment.
+The cluster is configured with one replica rings and can be used to test the Swift API.
 
 ## Deployment
 
-The file [`examples/swift/cluster.yml`](https://github.com/coreos/quartermaster/blob/master/examples/mock/cluster.yaml)
-contains an example deployment.
+The file [`examples/swift/cluster.yml`](https://github.com/coreos/quartermaster/blob/master/examples/swift/cluster.yaml)
+contains an example deployment. For quick testing you can use minikube for a
+single node deployment or try [kubernetes-swift](https://github.com/thiagodasilva/kubernetes-swift)
+for a 3 node deployment.
 
 ```
 $ kubectl create -f examples/swift/cluster.yaml
@@ -16,7 +18,7 @@ $ kubectl create -f examples/swift/cluster.yaml
 
 No dynamic provisioning or persistent volumes will be created since this is a
 fake storage system deployment. All data is being stored inside container and
-will be deleted once the container is deleted.
+will be deleted once the containers are deleted.
 
 You can check the status of the swift cluster running the following commands:
 
@@ -32,3 +34,7 @@ $ echo 'hello world' > hw
 $ swift -A http://<public-node-ip>:<node-port>/auth/v1.0 -U test:tester -K testing upload c1 hw
 $ swift -A http://<public-node-ip>:<node-port>/auth/v1.0 -U test:tester -K list c1
 ```
+
+Checkout this asciicast for a demo of deploying quartermaster and swift cluster:
+
+[![asciicast](https://asciinema.org/a/118177.png)](https://asciinema.org/a/118177?speed=2&autoplay=1)

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -258,7 +258,7 @@ func (st *SwiftStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Dep
 					},
 					api.Container{
 						Name:            "swift-ring-minion",
-						Image:           "thiagodasilva/swift_ring_minion:dev-v4",
+						Image:           "thiagodasilva/swift_ring_minion:dev-v5",
 						ImagePullPolicy: api.PullIfNotPresent,
 						VolumeMounts:    mounts,
 					},
@@ -403,7 +403,7 @@ func (st *SwiftStorage) deployProxy(namespace string) error {
 						},
 						api.Container{
 							Name:            "swift-ring-minion",
-							Image:           "thiagodasilva/swift_ring_minion:dev-v4",
+							Image:           "thiagodasilva/swift_ring_minion:dev-v5",
 							ImagePullPolicy: api.PullIfNotPresent,
 							VolumeMounts:    mounts,
 						},
@@ -588,7 +588,7 @@ func (st *SwiftStorage) deploySwiftRingMasterService(namespace string) error {
 			Selector: map[string]string{
 				"swift": "swift-ring-master",
 			},
-			ClusterIP: "10.0.0.248",
+			ClusterIP: "10.96.0.248", //10.96.253.129
 			Type:      api.ServiceTypeClusterIP,
 			Ports: []api.ServicePort{
 				api.ServicePort{

--- a/pkg/storage/swift/swift.go
+++ b/pkg/storage/swift/swift.go
@@ -15,12 +15,16 @@
 package swift
 
 import (
+	"encoding/json"
+
+	"github.com/coreos/quartermaster/pkg/operator"
 	"github.com/coreos/quartermaster/pkg/spec"
 	qmstorage "github.com/coreos/quartermaster/pkg/storage"
 	"github.com/heketi/utils"
 
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -28,7 +32,10 @@ import (
 )
 
 var (
-	logger = utils.NewLogger("swift", utils.LEVEL_DEBUG)
+	logger              = utils.NewLogger("swift", utils.LEVEL_DEBUG)
+	waitForDeploymentFn = func(client clientset.Interface, namespace, name string, available int32) error {
+		return operator.WaitForDeploymentReady(client, namespace, name, available)
+	}
 )
 
 // This mock storage system serves as an example driver for developers
@@ -100,6 +107,25 @@ func (st *SwiftStorage) Init() error {
 
 func (st *SwiftStorage) AddCluster(c *spec.StorageCluster) (*spec.StorageCluster, error) {
 	logger.Info("Add cluster %v", c.GetName())
+
+	// Create rings
+	err := st.createRings(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deploy swift proxies
+	err = st.deployProxy(c.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create service to access Swift Proxy API
+	err = st.deploySwiftProxyService(c.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -111,6 +137,33 @@ func (st *SwiftStorage) UpdateCluster(old *spec.StorageCluster,
 
 func (st *SwiftStorage) DeleteCluster(c *spec.StorageCluster) error {
 	logger.Info("Deleting cluster %v", c.GetName())
+	services := st.client.Core().Services(c.Namespace)
+	err := services.Delete("swiftservice", nil)
+	if err != nil {
+		return err
+	}
+
+	// TODO: deployment and replica set are being deleted, but the pod is not.
+	deployments := st.client.Extensions().Deployments(c.Namespace)
+	orphanDependents := false
+	err = deployments.Delete("swift-proxy-deploy",
+		&api.DeleteOptions{OrphanDependents: &orphanDependents})
+	if err != nil {
+		return err
+	}
+
+	jobs := st.client.Batch().Jobs(c.Namespace)
+	err = jobs.Delete("swift-ring-builder-job",
+		&api.DeleteOptions{OrphanDependents: &orphanDependents})
+	if err != nil {
+		return err
+	}
+
+	configMaps := st.client.Core().ConfigMaps(c.Namespace)
+	err = configMaps.Delete("swift-cluster-configmap", nil)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -120,7 +173,7 @@ func (st *SwiftStorage) MakeDeployment(s *spec.StorageNode,
 
 	logger.Debug("Make deployment for node %v", s.GetName())
 	if s.Spec.Image == "" {
-		s.Spec.Image = "thiagodasilva/swift-saio-poc"
+		s.Spec.Image = "thiagodasilva/swift-storage:dev-v1"
 	}
 	spec, err := st.makeDeploymentSpec(s)
 	if err != nil {
@@ -148,6 +201,23 @@ func (st *SwiftStorage) MakeDeployment(s *spec.StorageNode,
 
 func (st *SwiftStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.DeploymentSpec, error) {
 
+	volumes := []api.Volume{
+		api.Volume{
+			Name: "swift-storage-etc",
+			VolumeSource: api.VolumeSource{
+				HostPath: &api.HostPathVolumeSource{
+					Path: "/var/lib/swift_storage/etc",
+				},
+			},
+		},
+	}
+
+	mounts := []api.VolumeMount{
+		api.VolumeMount{
+			Name:      "swift-storage-etc",
+			MountPath: "/etc/swift",
+		},
+	}
 	spec := &extensions.DeploymentSpec{
 		Replicas: 1,
 		Template: api.PodTemplateSpec{
@@ -155,6 +225,7 @@ func (st *SwiftStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Dep
 				Labels: map[string]string{
 					// Drivers *should* add a quartermaster label
 					"quartermaster": s.Name,
+					"swift_storage": s.GetName(),
 				},
 			},
 			Spec: api.PodSpec{
@@ -165,13 +236,24 @@ func (st *SwiftStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Dep
 						Name:            s.Name,
 						Image:           s.Spec.Image,
 						ImagePullPolicy: api.PullIfNotPresent,
+						VolumeMounts:    mounts,
 						Ports: []api.ContainerPort{
 							api.ContainerPort{
-								ContainerPort: 8080,
+								// object server
+								ContainerPort: 6200,
+							},
+							api.ContainerPort{
+								// container server
+								ContainerPort: 6201,
+							},
+							api.ContainerPort{
+								// account server
+								ContainerPort: 6200,
 							},
 						},
 					},
 				},
+				Volumes: volumes,
 			},
 		},
 	}
@@ -180,12 +262,58 @@ func (st *SwiftStorage) makeDeploymentSpec(s *spec.StorageNode) (*extensions.Dep
 
 func (st *SwiftStorage) AddNode(s *spec.StorageNode) (*spec.StorageNode, error) {
 	logger.Info("Adding node %v", s.GetName())
-
-	// Create service to access Swift Proxy API
-	err := st.deploySwiftProxyService(s)
-	if err != nil {
-		return nil, err
+	svc := &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name:      s.GetName() + "-svc",
+			Namespace: s.Namespace,
+			Labels: map[string]string{
+				"swift": "swift-storage",
+			},
+			Annotations: map[string]string{
+				"description": "Exposes Swift Storage Service",
+			},
+		},
+		Spec: api.ServiceSpec{
+			Selector: map[string]string{
+				"swift_storage": s.GetName(),
+			},
+			ClusterIP: s.Spec.StorageNetwork.IPs[0],
+			Type:      api.ServiceTypeClusterIP,
+			Ports: []api.ServicePort{
+				api.ServicePort{
+					Name: "account",
+					Port: 6200,
+					TargetPort: intstr.IntOrString{
+						IntVal: 6200,
+					},
+				},
+				api.ServicePort{
+					Name: "container",
+					Port: 6201,
+					TargetPort: intstr.IntOrString{
+						IntVal: 6201,
+					},
+				},
+				api.ServicePort{
+					Name: "object",
+					Port: 6202,
+					TargetPort: intstr.IntOrString{
+						IntVal: 6202,
+					},
+				},
+			},
+		},
 	}
+
+	// Submit the service
+	services := st.client.Core().Services(s.Namespace)
+	_, err := services.Create(svc)
+	if apierrors.IsAlreadyExists(err) {
+		return nil, nil
+	} else if err != nil {
+		logger.Err(err)
+	}
+
 	return nil, nil
 }
 
@@ -197,7 +325,7 @@ func (st *SwiftStorage) UpdateNode(s *spec.StorageNode) (*spec.StorageNode, erro
 func (st *SwiftStorage) DeleteNode(s *spec.StorageNode) error {
 	logger.Info("Deleting storage node %v", s.GetName())
 	services := st.client.Core().Services(s.Namespace)
-	err := services.Delete("swiftservice", nil)
+	err := services.Delete(s.GetName()+"-svc", nil)
 	if err != nil {
 		return err
 	}
@@ -210,11 +338,90 @@ func (st *SwiftStorage) Type() spec.StorageTypeIdentifier {
 	return spec.StorageTypeIdentifierSwift
 }
 
-func (st *SwiftStorage) deploySwiftProxyService(sns *spec.StorageNode) error {
+func (st *SwiftStorage) deployProxy(namespace string) error {
+	volumes := []api.Volume{
+		api.Volume{
+			Name: "swift-proxy-etc",
+			VolumeSource: api.VolumeSource{
+				HostPath: &api.HostPathVolumeSource{
+					Path: "/var/lib/swift_proxy/etc",
+				},
+			},
+		},
+	}
+
+	mounts := []api.VolumeMount{
+		api.VolumeMount{
+			Name:      "swift-proxy-etc",
+			MountPath: "/etc/swift",
+		},
+	}
+	proxyDeploy := &extensions.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "swift-proxy-deploy",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"description": "Deployment spec for Swift proxy",
+			},
+			Labels: map[string]string{
+				"swift":         "swift-proxy",
+				"quartermaster": "swift",
+			},
+		},
+		Spec: extensions.DeploymentSpec{
+			Replicas: 1,
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"swift":         "swift-proxy",
+						"quartermaster": "swift",
+					},
+					Name: "swift-proxy-pod",
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						api.Container{
+							Name:            "swift-proxy",
+							Image:           "thiagodasilva/swift-proxy:dev-v1",
+							ImagePullPolicy: api.PullIfNotPresent,
+							VolumeMounts:    mounts,
+							Ports: []api.ContainerPort{
+								api.ContainerPort{
+									ContainerPort: 8080,
+								},
+							},
+						},
+					},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+
+	deployments := st.client.Extensions().Deployments(namespace)
+	_, err := deployments.Create(proxyDeploy)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		logger.Err(err)
+	}
+
+	// Wait until deployment ready
+	err = waitForDeploymentFn(st.client, namespace, proxyDeploy.GetName(),
+		proxyDeploy.Spec.Replicas)
+	if err != nil {
+		return logger.Err(err)
+	}
+
+	logger.Debug("swift-proxy pod deployed")
+	return nil
+}
+
+func (st *SwiftStorage) deploySwiftProxyService(namespace string) error {
 	s := &api.Service{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "swiftservice",
-			Namespace: sns.Namespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				"swift": "swift-service",
 			},
@@ -224,7 +431,7 @@ func (st *SwiftStorage) deploySwiftProxyService(sns *spec.StorageNode) error {
 		},
 		Spec: api.ServiceSpec{
 			Selector: map[string]string{
-				"quartermaster": sns.Name,
+				"swift": "swift-proxy",
 			},
 			Type: api.ServiceTypeNodePort,
 			Ports: []api.ServicePort{
@@ -239,14 +446,129 @@ func (st *SwiftStorage) deploySwiftProxyService(sns *spec.StorageNode) error {
 	}
 
 	// Submit the service
-	services := st.client.Core().Services(sns.Namespace)
+	services := st.client.Core().Services(namespace)
 	_, err := services.Create(s)
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	} else if err != nil {
 		logger.Err(err)
+		return err
 	}
 
 	logger.Debug("swift proxy service created")
+	return nil
+}
+
+func (st *SwiftStorage) createRings(c *spec.StorageCluster) error {
+	// Create configMap with cluster topology
+	err := st.createConfigMap(c)
+	if err != nil {
+		return err
+	}
+
+	volumes := []api.Volume{
+		api.Volume{
+			Name: "swift-proxy-etc",
+			VolumeSource: api.VolumeSource{
+				HostPath: &api.HostPathVolumeSource{
+					Path: "/var/lib/swift_proxy/etc",
+				},
+			},
+		},
+		api.Volume{
+			Name: "swift-storage-etc",
+			VolumeSource: api.VolumeSource{
+				HostPath: &api.HostPathVolumeSource{
+					Path: "/var/lib/swift_storage/etc",
+				},
+			},
+		},
+		api.Volume{
+			Name: "config-swift-cluster",
+			VolumeSource: api.VolumeSource{
+				ConfigMap: &api.ConfigMapVolumeSource{
+					LocalObjectReference: api.LocalObjectReference{
+						Name: "swift-cluster-configmap"},
+					Items: []api.KeyToPath{{
+						Key:  "cluster.json",
+						Path: "cluster_topology.json",
+					}},
+				},
+			},
+		},
+	}
+
+	mounts := []api.VolumeMount{
+		api.VolumeMount{
+			Name:      "swift-proxy-etc",
+			MountPath: "/etc/proxy_rings",
+		},
+		api.VolumeMount{
+			Name:      "swift-storage-etc",
+			MountPath: "/etc/storage_rings",
+		},
+		api.VolumeMount{
+			Name:      "config-swift-cluster",
+			MountPath: "/etc/swift_config",
+		},
+	}
+
+	ringJob := &batch.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name: "swift-ring-builder-job",
+		},
+		Spec: batch.JobSpec{
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Name: "swift-ring-builder-pod",
+				},
+
+				Spec: api.PodSpec{
+					RestartPolicy: api.RestartPolicyNever,
+					Containers: []api.Container{
+						api.Container{
+							Name:  "swift-ring-builder-container",
+							Image: "thiagodasilva/swift_ring_builder:dev-v4",
+							Command: []string{
+								"/etc/swift/make_rings.sh",
+							},
+							VolumeMounts: mounts,
+						},
+					},
+					Volumes: volumes,
+				},
+			},
+		},
+	}
+
+	jobs := st.client.Batch().Jobs(c.Namespace)
+	_, err = jobs.Create(ringJob)
+	if err != nil {
+		logger.Err(err)
+	}
+	logger.Debug("rings created")
+
+	return nil
+}
+
+func (st *SwiftStorage) createConfigMap(c *spec.StorageCluster) error {
+	cluster, _ := json.Marshal(c)
+	clusterConfMap := &api.ConfigMap{
+		ObjectMeta: api.ObjectMeta{
+			Name: "swift-cluster-configmap",
+		},
+		Data: map[string]string{
+			"cluster.json": string(cluster),
+		},
+	}
+	configMaps := st.client.Core().ConfigMaps(c.Namespace)
+	_, err := configMaps.Create(clusterConfMap)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		logger.Err(err)
+		return err
+	}
+	logger.Debug("created config map")
 	return nil
 }


### PR DESCRIPTION
This change extends the swift driver from a single node SAIO deployment to support a multi-node deployment. The driver now creates multiple kubernetes resources to deploy a proxy, ring-master and multiple swift storage services.