### PR TITLE
Update to Kubernetes 1.6 APIs

### DIFF
--- a/cmd/quartermaster/main.go
+++ b/cmd/quartermaster/main.go
@@ -41,6 +41,7 @@ func init() {
 	flagset.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")
 	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
+	flagset.StringVar(&cfg.Kubeconfig, "kubeconfig", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to kubeconfig.")
 	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
 
 	flagset.Parse(os.Args[1:])

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ac12de7748df86ed9485528e001d3c58e9bc1bb4deab071b687a6296fe67ef76
-updated: 2017-03-20T16:43:16.486567972-04:00
+hash: 0a85b0681e66010240cf259fbd5163537bb25feafd6fc62905da1c9b19132767
+updated: 2017-05-23T20:39:22.410948089-04:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -12,12 +12,10 @@ imports:
   version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
   subpackages:
   - winterm
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/boltdb/bolt
   version: dfb21201d9270c1082d5fb0f07f500311ff72f18
 - name: github.com/coreos/go-oidc
-  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
+  version: be73733bb8cc830d0205609b95d125215f8e9c70
   subpackages:
   - http
   - jose
@@ -27,8 +25,6 @@ imports:
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
-  - capnslog
-  - dlopen
   - health
   - httputil
   - timeutil
@@ -78,13 +74,13 @@ imports:
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
-  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
+  version: e30f1e79f3cd72542f2026ceec18d3bd67ab859c
 - name: github.com/docker/spdystream
   version: 449fdfce4d962303d702fec724ef0ad181c92528
   subpackages:
   - spdy
 - name: github.com/emicklei/go-restful
-  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
   - log
   - swagger
@@ -103,31 +99,8 @@ imports:
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
-  - gogoproto
-  - plugin/compare
-  - plugin/defaultcheck
-  - plugin/description
-  - plugin/embedcheck
-  - plugin/enumstringer
-  - plugin/equal
-  - plugin/face
-  - plugin/gostring
-  - plugin/marshalto
-  - plugin/oneofcheck
-  - plugin/populate
-  - plugin/size
-  - plugin/stringer
-  - plugin/testgen
-  - plugin/union
-  - plugin/unmarshal
   - proto
-  - protoc-gen-gogo/descriptor
-  - protoc-gen-gogo/generator
-  - protoc-gen-gogo/grpc
-  - protoc-gen-gogo/plugin
   - sortkeys
-  - vanity
-  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
@@ -137,16 +110,16 @@ imports:
 - name: github.com/golang/protobuf
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
-  - jsonpb
   - proto
 - name: github.com/google/gofuzz
-  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/gorilla/mux
   version: 8096f47503459bcc74d1f4c487b7e6e42e5746b5
 - name: github.com/heketi/heketi
-  version: 9a70d23952f5acbb932ce45c91e3afe4325c2eb0
+  version: 04cf4bbced8e0835c31d1e3e397805eff3bd24c4
+  repo: https://github.com/lpabon/heketi.git
   subpackages:
   - apps/glusterfs
   - client/api/go-client
@@ -158,6 +131,7 @@ imports:
   - pkg/db
   - pkg/glusterfs/api
   - pkg/heketitest
+  - pkg/kubernetes
   - pkg/utils
   - pkg/utils/ssh
 - name: github.com/heketi/rest
@@ -166,6 +140,10 @@ imports:
   version: f3775cbcefd6822086c729e3ce4b70ca85a5bd21
 - name: github.com/heketi/utils
   version: 435bc5bdfa64550e867cd7ef0b9181adc02b88d2
+- name: github.com/howeyc/gopass
+  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
+- name: github.com/imdario/mergo
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jonboulle/clockwork
@@ -195,34 +173,31 @@ imports:
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
-  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
-  - codec/codecgen
 - name: github.com/urfave/negroni
-  version: cd9734011043904139c24dbad9a71b21f1586f36
+  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
 - name: golang.org/x/crypto
-  version: 1f22c0103821b9390939b6776727195525381532
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
   - ssh
   - ssh/agent
+  - ssh/terminal
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
   - context
   - context/ctxhttp
-  - html
-  - html/atom
   - http2
   - http2/hpack
   - idna
-  - internal/timeseries
   - lex/httplex
-  - proxy
-  - trace
   - websocket
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
@@ -239,7 +214,12 @@ imports:
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
   - cases
+  - encoding
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/unicode
   - internal/tag
+  - internal/utf8internal
   - language
   - runes
   - secure/bidirule
@@ -264,201 +244,313 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
-- name: k8s.io/kubernetes
-  version: 7243c69eb523aa4377bce883e7c0dd76b84709a1
+- name: k8s.io/apimachinery
+  version: 75b8dd260ef0469d96d578705a87cffd0e09dab8
   subpackages:
-  - cmd/kubeadm/app/apis/kubeadm
-  - cmd/kubeadm/app/apis/kubeadm/install
-  - cmd/kubeadm/app/apis/kubeadm/v1alpha1
-  - federation/apis/federation
-  - federation/apis/federation/install
-  - federation/apis/federation/v1beta1
-  - federation/client/clientset_generated/federation_internalclientset
-  - federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion
-  - federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion
-  - federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion
-  - pkg/api
-  - pkg/api/annotations
-  - pkg/api/endpoints
+  - pkg/api/equality
   - pkg/api/errors
-  - pkg/api/events
-  - pkg/api/install
   - pkg/api/meta
-  - pkg/api/meta/metatypes
-  - pkg/api/pod
   - pkg/api/resource
-  - pkg/api/service
-  - pkg/api/testapi
-  - pkg/api/unversioned
-  - pkg/api/unversioned/validation
-  - pkg/api/util
-  - pkg/api/v1
   - pkg/api/validation
-  - pkg/api/validation/path
   - pkg/apimachinery
   - pkg/apimachinery/announced
   - pkg/apimachinery/registered
-  - pkg/apis/apps
-  - pkg/apis/apps/install
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/install
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/install
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/batch
-  - pkg/apis/batch/install
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1alpha1
-  - pkg/apis/componentconfig
-  - pkg/apis/componentconfig/install
-  - pkg/apis/componentconfig/v1alpha1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/imagepolicy
-  - pkg/apis/imagepolicy/install
-  - pkg/apis/imagepolicy/v1alpha1
-  - pkg/apis/policy
-  - pkg/apis/policy/install
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/install
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/install
-  - pkg/apis/storage/util
-  - pkg/apis/storage/v1beta1
-  - pkg/auth/authenticator
-  - pkg/auth/user
-  - pkg/capabilities
-  - pkg/client/cache
-  - pkg/client/clientset_generated/internalclientset
-  - pkg/client/clientset_generated/internalclientset/fake
-  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake
-  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
-  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/fake
-  - pkg/client/clientset_generated/release_1_5
-  - pkg/client/clientset_generated/release_1_5/typed/apps/v1beta1
-  - pkg/client/clientset_generated/release_1_5/typed/authentication/v1beta1
-  - pkg/client/clientset_generated/release_1_5/typed/authorization/v1beta1
-  - pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1
-  - pkg/client/clientset_generated/release_1_5/typed/batch/v1
-  - pkg/client/clientset_generated/release_1_5/typed/batch/v2alpha1
-  - pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1
-  - pkg/client/clientset_generated/release_1_5/typed/core/v1
-  - pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1
-  - pkg/client/clientset_generated/release_1_5/typed/policy/v1beta1
-  - pkg/client/clientset_generated/release_1_5/typed/rbac/v1alpha1
-  - pkg/client/clientset_generated/release_1_5/typed/storage/v1beta1
-  - pkg/client/metrics
-  - pkg/client/record
-  - pkg/client/restclient
-  - pkg/client/restclient/fake
-  - pkg/client/retry
-  - pkg/client/testing/core
-  - pkg/client/transport
-  - pkg/client/typed/discovery
-  - pkg/client/typed/discovery/fake
-  - pkg/client/unversioned
-  - pkg/client/unversioned/clientcmd/api
-  - pkg/client/unversioned/remotecommand
-  - pkg/controller
-  - pkg/controller/deployment/util
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1/validation
   - pkg/conversion
   - pkg/conversion/queryparams
-  - pkg/credentialprovider
-  - pkg/fieldpath
   - pkg/fields
-  - pkg/genericapiserver/openapi/common
-  - pkg/httplog
-  - pkg/kubectl
-  - pkg/kubectl/resource
-  - pkg/kubelet/qos
-  - pkg/kubelet/server/remotecommand
-  - pkg/kubelet/types
   - pkg/labels
-  - pkg/master/ports
+  - pkg/openapi
   - pkg/runtime
+  - pkg/runtime/schema
   - pkg/runtime/serializer
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
-  - pkg/security/apparmor
   - pkg/selection
-  - pkg/serviceaccount
   - pkg/types
-  - pkg/util
-  - pkg/util/cert
-  - pkg/util/clock
-  - pkg/util/config
   - pkg/util/diff
   - pkg/util/errors
-  - pkg/util/exec
-  - pkg/util/flowcontrol
   - pkg/util/framer
-  - pkg/util/hash
   - pkg/util/httpstream
   - pkg/util/httpstream/spdy
-  - pkg/util/integer
-  - pkg/util/interrupt
   - pkg/util/intstr
   - pkg/util/json
-  - pkg/util/jsonpath
-  - pkg/util/labels
+  - pkg/util/mergepatch
   - pkg/util/net
-  - pkg/util/net/sets
-  - pkg/util/node
-  - pkg/util/parsers
-  - pkg/util/pod
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
-  - pkg/util/slice
   - pkg/util/strategicpatch
-  - pkg/util/term
   - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
-  - pkg/util/wsstream
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
-  - pkg/watch/versioned
-  - plugin/pkg/client/auth
-  - plugin/pkg/client/auth/gcp
-  - plugin/pkg/client/auth/oidc
   - third_party/forked/golang/json
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
+- name: k8s.io/apiserver
+  version: c809cf8581e1e44c6174bf5ab4415e6ee39965ca
+  subpackages:
+  - pkg/authentication/authenticator
+  - pkg/authentication/serviceaccount
+  - pkg/authentication/user
+  - pkg/features
+  - pkg/server/httplog
+  - pkg/util/feature
+  - pkg/util/wsstream
+- name: k8s.io/client-go
+  version: 3627aeb7d4f6ade38f995d2c923e459146493c7e
+  subpackages:
+  - discovery
+  - discovery/fake
+  - dynamic
+  - kubernetes
+  - kubernetes/fake
+  - kubernetes/scheme
+  - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta1/fake
+  - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1/fake
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authentication/v1beta1/fake
+  - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1/fake
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/authorization/v1beta1/fake
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v1/fake
+  - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2alpha1/fake
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1/fake
+  - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/batch/v2alpha1/fake
+  - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/certificates/v1beta1/fake
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/core/v1/fake
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/extensions/v1beta1/fake
+  - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/policy/v1beta1/fake
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1alpha1/fake
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/rbac/v1beta1/fake
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/settings/v1alpha1/fake
+  - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1/fake
+  - kubernetes/typed/storage/v1beta1
+  - kubernetes/typed/storage/v1beta1/fake
+  - pkg/api
+  - pkg/api/install
+  - pkg/api/v1
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
+  - pkg/util
+  - pkg/util/parsers
+  - pkg/version
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - rest
+  - rest/fake
+  - rest/watch
+  - testing
   - third_party/forked/golang/template
+  - tools/auth
+  - tools/cache
+  - tools/clientcmd
+  - tools/clientcmd/api
+  - tools/clientcmd/api/latest
+  - tools/clientcmd/api/v1
+  - tools/metrics
+  - tools/record
+  - transport
+  - util/cert
+  - util/clock
+  - util/flowcontrol
+  - util/homedir
+  - util/integer
+  - util/jsonpath
+- name: k8s.io/kubernetes
+  version: d6f433224538d4f9ca2f7ae19b252e6fcb66a3ae
+  subpackages:
+  - federation/apis/federation
+  - federation/apis/federation/install
+  - federation/apis/federation/v1beta1
+  - federation/client/clientset_generated/federation_internalclientset
+  - federation/client/clientset_generated/federation_internalclientset/scheme
+  - federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion
+  - federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion
+  - pkg/api
+  - pkg/api/annotations
+  - pkg/api/events
+  - pkg/api/install
+  - pkg/api/pod
+  - pkg/api/service
+  - pkg/api/util
+  - pkg/api/v1
+  - pkg/api/validation
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
+  - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/util
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
+  - pkg/capabilities
+  - pkg/client/clientset_generated/clientset
+  - pkg/client/clientset_generated/clientset/scheme
+  - pkg/client/clientset_generated/clientset/typed/apps/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/batch/v1
+  - pkg/client/clientset_generated/clientset/typed/batch/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/certificates/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/core/v1
+  - pkg/client/clientset_generated/clientset/typed/extensions/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/policy/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/settings/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1beta1
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/clientset_generated/internalclientset/scheme
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/settings/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
+  - pkg/client/listers/core/v1
+  - pkg/client/listers/extensions/v1beta1
+  - pkg/client/retry
+  - pkg/client/unversioned
+  - pkg/client/unversioned/remotecommand
+  - pkg/controller
+  - pkg/controller/deployment/util
+  - pkg/credentialprovider
+  - pkg/features
+  - pkg/fieldpath
+  - pkg/kubectl
+  - pkg/kubectl/resource
+  - pkg/kubelet/qos
+  - pkg/kubelet/server/remotecommand
+  - pkg/kubelet/types
+  - pkg/master/ports
+  - pkg/printers
+  - pkg/printers/internalversion
+  - pkg/security/apparmor
+  - pkg/serviceaccount
+  - pkg/util
+  - pkg/util/exec
+  - pkg/util/hash
+  - pkg/util/interrupt
+  - pkg/util/labels
+  - pkg/util/net/sets
+  - pkg/util/node
+  - pkg/util/parsers
+  - pkg/util/slice
+  - pkg/util/term
+- name: vbom.ml/util
+  version: db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394
+  subpackages:
+  - sortorder
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,8 @@
 package: github.com/coreos/quartermaster
 import:
 - package: github.com/heketi/heketi
-  version: 9a70d23952f5acbb932ce45c91e3afe4325c2eb0
+  repo: https://github.com/lpabon/heketi.git
+  version: 04cf4bbced8e0835c31d1e3e397805eff3bd24c4
   subpackages:
   - pkg/heketitest
   - pkg/glusterfs/api
@@ -9,28 +10,5 @@ import:
   version: 435bc5bdfa64550e867cd7ef0b9181adc02b88d2
 - package: github.com/heketi/tests
   version: f3775cbcefd6822086c729e3ce4b70ca85a5bd21
-- package: k8s.io/kubernetes
-  version: v1.5.4
-  subpackages:
-  - pkg/api
-  - pkg/api/errors
-  - pkg/api/unversioned
-  - pkg/api/v1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/v1beta1
-  - pkg/api/meta
-  - pkg/client/cache
-  - pkg/client/clientset_generated/internalclientset
-  - pkg/client/restclient
-  - pkg/kubectl
-  - pkg/labels
-  - pkg/runtime
-  - pkg/runtime/serializer
-  - pkg/util/runtime
-  - pkg/util/wait
-  - pkg/watch
-- package: github.com/lpabon/godbc
-- package: golang.org/x/crypto
-  subpackages:
-  - ssh
-  - ssh/agent
+- package: k8s.io/client-go
+  version: v3.0.0-beta.0

--- a/pkg/client/storagecluster.go
+++ b/pkg/client/storagecluster.go
@@ -17,8 +17,8 @@ package client
 import (
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/client-go/pkg/api"
+	restclient "k8s.io/client-go/rest"
 )
 
 type StorageClusters struct {
@@ -40,7 +40,7 @@ func (c *StorageClusters) Create(storageCluster *spec.StorageCluster) (result *s
 }
 
 func (c *StorageClusters) Update(storageCluster *spec.StorageCluster) (result *spec.StorageCluster, err error) {
-	obj, err := c.t.Update(storageCluster, storageCluster.GetName(), &spec.StorageCluster{})
+	obj, err := c.t.Update(storageCluster, storageCluster.Name, &spec.StorageCluster{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/storagenode.go
+++ b/pkg/client/storagenode.go
@@ -17,8 +17,8 @@ package client
 import (
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/client-go/pkg/api"
+	restclient "k8s.io/client-go/rest"
 )
 
 type StorageNodes struct {
@@ -40,7 +40,7 @@ func (c *StorageNodes) Create(storageNode *spec.StorageNode) (result *spec.Stora
 }
 
 func (c *StorageNodes) Update(storageNode *spec.StorageNode) (result *spec.StorageNode, err error) {
-	obj, err := c.t.Update(storageNode, storageNode.GetName(), &spec.StorageNode{})
+	obj, err := c.t.Update(storageNode, storageNode.Name, &spec.StorageNode{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/transport.go
+++ b/pkg/client/transport.go
@@ -17,8 +17,8 @@ package client
 import (
 	"encoding/json"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/client-go/pkg/api"
+	restclient "k8s.io/client-go/rest"
 )
 
 type transport struct {

--- a/pkg/operator/client.go
+++ b/pkg/operator/client.go
@@ -20,20 +20,21 @@ import (
 
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/client/cache"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/runtime/serializer"
-	"k8s.io/kubernetes/pkg/watch"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/pkg/api"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 )
 
 const resyncPeriod = 5 * time.Minute
 
 func NewQuartermasterRESTClient(c restclient.Config) (*restclient.RESTClient, error) {
 	c.APIPath = "/apis"
-	c.GroupVersion = &unversioned.GroupVersion{
+	c.GroupVersion = &schema.GroupVersion{
 		Group:   "storage.coreos.com",
 		Version: "v1alpha1",
 	}
@@ -57,7 +58,7 @@ func (d *storageNodeDecoder) Decode() (action watch.EventType, object runtime.Ob
 		Object spec.StorageNode
 	}
 	if err := d.dec.Decode(&e); err != nil {
-		return watch.Error, nil, err
+		return watch.Error, nil, logger.Err(err)
 	}
 	return e.Type, &e.Object, nil
 }
@@ -72,7 +73,7 @@ func (d *storageClusterDecoder) Decode() (action watch.EventType, object runtime
 		Object spec.StorageCluster
 	}
 	if err := d.dec.Decode(&e); err != nil {
-		return watch.Error, nil, err
+		return watch.Error, nil, logger.Err(err)
 	}
 	return e.Type, &e.Object, nil
 }
@@ -80,7 +81,7 @@ func (d *storageClusterDecoder) Decode() (action watch.EventType, object runtime
 // NewStorageNodeListWatch returns a new ListWatch on the StorageNode resource.
 func NewStorageNodeListWatch(client *restclient.RESTClient) *cache.ListWatch {
 	return &cache.ListWatch{
-		ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+		ListFunc: func(options meta.ListOptions) (runtime.Object, error) {
 			req := client.Get().
 				Namespace(api.NamespaceAll).
 				Resource("storagenodes").
@@ -94,7 +95,7 @@ func NewStorageNodeListWatch(client *restclient.RESTClient) *cache.ListWatch {
 			var p spec.StorageNodeList
 			return &p, json.Unmarshal(b, &p)
 		},
-		WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options meta.ListOptions) (watch.Interface, error) {
 			r, err := client.Get().
 				Prefix("watch").
 				Namespace(api.NamespaceAll).
@@ -116,7 +117,7 @@ func NewStorageNodeListWatch(client *restclient.RESTClient) *cache.ListWatch {
 // NewStorageClusterListWatch returns a new ListWatch on the StorageCluster resource.
 func NewStorageClusterListWatch(client *restclient.RESTClient) *cache.ListWatch {
 	return &cache.ListWatch{
-		ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+		ListFunc: func(options meta.ListOptions) (runtime.Object, error) {
 			req := client.Get().
 				Namespace(api.NamespaceAll).
 				Resource("storageclusters").
@@ -130,7 +131,7 @@ func NewStorageClusterListWatch(client *restclient.RESTClient) *cache.ListWatch 
 			var p spec.StorageClusterList
 			return &p, json.Unmarshal(b, &p)
 		},
-		WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+		WatchFunc: func(options meta.ListOptions) (watch.Interface, error) {
 			r, err := client.Get().
 				Prefix("watch").
 				Namespace(api.NamespaceAll).

--- a/pkg/operator/cluster_operator.go
+++ b/pkg/operator/cluster_operator.go
@@ -21,12 +21,12 @@ import (
 	qmclient "github.com/coreos/quartermaster/pkg/client"
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/client/cache"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/tools/cache"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
-	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 )
 
 type StorageOperator interface {
@@ -229,7 +229,7 @@ func (s *StorageClusterOperator) submitNodesFor(cs *spec.StorageCluster) error {
 	ns_client := qmclient.NewStorageNodes(s.op.GetRESTClient(), cs.Namespace)
 
 	// Create a reference object
-	clusterRef, err := api.GetReference(cs)
+	clusterRef, err := api.GetReference(api.Scheme, cs)
 	if err != nil {
 		return logger.Err(err)
 	}
@@ -243,11 +243,11 @@ func (s *StorageClusterOperator) submitNodesFor(cs *spec.StorageCluster) error {
 
 		// Setup StorageNode object
 		node := &spec.StorageNode{
-			TypeMeta: unversioned.TypeMeta{
+			TypeMeta: meta.TypeMeta{
 				Kind:       "StorageNode",
 				APIVersion: cs.APIVersion,
 			},
-			ObjectMeta: api.ObjectMeta{
+			ObjectMeta: meta.ObjectMeta{
 				Name:      cs.Name + "-" + fmt.Sprintf("%d", storageNodeSpecHash),
 				Namespace: cs.Namespace,
 				Labels:    cs.GetLabels(),

--- a/pkg/operator/k8sutil.go
+++ b/pkg/operator/k8sutil.go
@@ -19,11 +19,12 @@ import (
 	"net/http"
 	"time"
 
-	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/api/v1"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/util/wait"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	restclient "k8s.io/client-go/rest"
 )
 
 // WaitForTPRReady waits for a third party resource to be available
@@ -53,10 +54,10 @@ func WaitForTPRReady(restClient restclient.Interface, tprGroup, tprVersion, tprN
 	})
 }
 
-func WaitForDeploymentReady(client clientset.Interface, namespace, name string, available int32) error {
+func WaitForDeploymentReady(client kubernetes.Interface, namespace, name string, available int32) error {
 	return wait.Poll(3*time.Second, 10*time.Minute, func() (bool, error) {
 		deployments := client.Extensions().Deployments(namespace)
-		deployment, err := deployments.Get(name)
+		deployment, err := deployments.Get(name, meta.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -15,9 +15,9 @@
 package operator
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/apis/extensions"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 const (
@@ -44,36 +44,36 @@ var (
 )
 
 func (c *Operator) createTPRs() error {
-	tprs := []*extensions.ThirdPartyResource{
+	tprs := []*v1beta1.ThirdPartyResource{
 		{
-			ObjectMeta: api.ObjectMeta{
+			ObjectMeta: meta.ObjectMeta{
 				Name: tprStorageStatus,
 			},
-			Versions: []extensions.APIVersion{
+			Versions: []v1beta1.APIVersion{
 				{Name: TPRVersion},
 			},
 			Description: "Status reports from Quartermaster managed storage",
 		},
 		{
-			ObjectMeta: api.ObjectMeta{
+			ObjectMeta: meta.ObjectMeta{
 				Name: tprStorageNode,
 			},
-			Versions: []extensions.APIVersion{
+			Versions: []v1beta1.APIVersion{
 				{Name: TPRVersion},
 			},
 			Description: "Managed storage nodes via Quartermaster",
 		},
 		{
-			ObjectMeta: api.ObjectMeta{
+			ObjectMeta: meta.ObjectMeta{
 				Name: tprStorageCluster,
 			},
-			Versions: []extensions.APIVersion{
+			Versions: []v1beta1.APIVersion{
 				{Name: TPRVersion},
 			},
 			Description: "Managed storage clusters via Quartermaster",
 		},
 	}
-	tprClient := c.kclient.Extensions().ThirdPartyResources()
+	tprClient := c.kclient.ExtensionsV1beta1().ThirdPartyResources()
 	for _, tpr := range tprs {
 		_, err := tprClient.Create(tpr)
 		if apierrors.IsAlreadyExists(err) {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -19,17 +19,17 @@
 package spec
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api"
 )
 
 // StorageNode defines a single instance of available storage on a
 // node and the appropriate options to apply to it to make it available
 // to the cluster.
 type StorageNode struct {
-	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
-	Spec                 StorageNodeSpec `json:"spec,omitempty"`
+	meta.TypeMeta   `json:",inline"`
+	meta.ObjectMeta `json:"metadata,omitempty"`
+	Spec            StorageNodeSpec `json:"spec,omitempty"`
 
 	// Status represents the current status of the storage node
 	// +optional
@@ -39,9 +39,9 @@ type StorageNode struct {
 // Third Party Resource object which contains all the necessary information
 // to deploy a storage cluster
 type StorageCluster struct {
-	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
-	Spec                 StorageClusterSpec `json:"spec,omitempty"`
+	meta.TypeMeta   `json:",inline"`
+	meta.ObjectMeta `json:"metadata,omitempty"`
+	Spec            StorageClusterSpec `json:"spec,omitempty"`
 
 	// Status represents the current status of the storage node
 	// +optional
@@ -50,16 +50,16 @@ type StorageCluster struct {
 
 // StorageNodeList is a list of StorageNode objects in Kubernetes.
 type StorageNodeList struct {
-	unversioned.TypeMeta `json:",inline"`
-	unversioned.ListMeta `json:"metadata,omitempty"`
+	meta.TypeMeta `json:",inline"`
+	meta.ListMeta `json:"metadata,omitempty"`
 
 	Items []StorageNode `json:"items"`
 }
 
 // StorageClusterList is a list of StorageCluster objects in Kubernetes
 type StorageClusterList struct {
-	unversioned.TypeMeta `json:",inline"`
-	unversioned.ListMeta `json:"metadata,omitempty"`
+	meta.TypeMeta `json:",inline"`
+	meta.ListMeta `json:"metadata,omitempty"`
 
 	Items []StorageCluster `json:"items"`
 }
@@ -169,9 +169,9 @@ type NFSStorageNode struct {
 }
 
 type StatusCondition struct {
-	Time    unversioned.Time `json:"time,omitempty"`
-	Message string           `json:"message,omitempty"`
-	Reason  string           `json:"reason,omitempty"`
+	Time    meta.Time `json:"time,omitempty"`
+	Message string    `json:"message,omitempty"`
+	Reason  string    `json:"reason,omitempty"`
 }
 
 type StatusInfo struct {

--- a/pkg/storage/glusterfs/glusterfs_kube.go
+++ b/pkg/storage/glusterfs/glusterfs_kube.go
@@ -17,131 +17,132 @@ package glusterfs
 import (
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/apis/extensions"
-	kubestorage "k8s.io/kubernetes/pkg/apis/storage"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	storageclasspkg "k8s.io/client-go/pkg/apis/storage/v1"
 )
 
 const (
 	glusterfsRoot = "/var/lib/glusterfs-container"
 )
 
-func (st *GlusterStorage) makeGlusterFSDeploymentSpec(s *spec.StorageNode) (*extensions.DeploymentSpec, error) {
-	volumes := []api.Volume{
-		api.Volume{
+func (st *GlusterStorage) makeGlusterFSDeploymentSpec(s *spec.StorageNode) (*v1beta1.DeploymentSpec, error) {
+	volumes := []v1.Volume{
+		v1.Volume{
 			Name: "glusterfs-heketi",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: glusterfsRoot + "/heketi",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-run",
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-lvm",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: "/run/lvm",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-etc",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: glusterfsRoot + "/etc",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-logs",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: glusterfsRoot + "/logs",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-config",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: glusterfsRoot + "/glusterd",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-dev",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: "/dev",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-cgroup",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: "/sys/fs/cgroup",
 				},
 			},
 		},
-		api.Volume{
+		v1.Volume{
 			Name: "glusterfs-misc",
-			VolumeSource: api.VolumeSource{
-				HostPath: &api.HostPathVolumeSource{
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: glusterfsRoot + "/glusterfsd-misc",
 				},
 			},
 		},
 	}
 
-	mounts := []api.VolumeMount{
-		api.VolumeMount{
+	mounts := []v1.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-heketi",
 			MountPath: "/var/lib/heketi",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-run",
 			MountPath: "/run",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-lvm",
 			MountPath: "/run/lvm",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-etc",
 			MountPath: "/etc/glusterfs",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-logs",
 			MountPath: "/var/log/glusterfs",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-config",
 			MountPath: "/var/lib/glusterd",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-dev",
 			MountPath: "/dev",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-cgroup",
 			MountPath: "/sys/fs/cgroup",
 		},
-		api.VolumeMount{
+		v1.VolumeMount{
 			Name:      "glusterfs-misc",
 			MountPath: "/var/lib/misc/glusterfsd",
 		},
 	}
 
-	probe := &api.Probe{
+	probe := &v1.Probe{
 		TimeoutSeconds:      3,
 		InitialDelaySeconds: 60,
-		Handler: api.Handler{
-			Exec: &api.ExecAction{
+		Handler: v1.Handler{
+			Exec: &v1.ExecAction{
 				Command: []string{
 					"/bin/bash",
 					"-c",
@@ -152,10 +153,11 @@ func (st *GlusterStorage) makeGlusterFSDeploymentSpec(s *spec.StorageNode) (*ext
 	}
 
 	priv := true
-	spec := &extensions.DeploymentSpec{
-		Replicas: 1,
-		Template: api.PodTemplateSpec{
-			ObjectMeta: api.ObjectMeta{
+	replicas := int32(1)
+	spec := &v1beta1.DeploymentSpec{
+		Replicas: &replicas,
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: meta.ObjectMeta{
 				Labels: map[string]string{
 					"quartermaster":  s.Name,
 					"name":           "glusterfs",
@@ -164,26 +166,24 @@ func (st *GlusterStorage) makeGlusterFSDeploymentSpec(s *spec.StorageNode) (*ext
 				},
 				Name: s.Name,
 			},
-			Spec: api.PodSpec{
+			Spec: v1.PodSpec{
 				NodeName:     s.Spec.NodeName,
 				NodeSelector: s.Spec.NodeSelector,
-				Containers: []api.Container{
-					api.Container{
+				Containers: []v1.Container{
+					v1.Container{
 						Name:            s.Name,
 						Image:           s.Spec.Image,
-						ImagePullPolicy: api.PullIfNotPresent,
+						ImagePullPolicy: v1.PullIfNotPresent,
 						VolumeMounts:    mounts,
 						LivenessProbe:   probe,
 						ReadinessProbe:  probe,
-						SecurityContext: &api.SecurityContext{
+						SecurityContext: &v1.SecurityContext{
 							Privileged: &priv,
 						},
 					},
 				},
-				Volumes: volumes,
-				SecurityContext: &api.PodSecurityContext{
-					HostNetwork: true,
-				},
+				Volumes:     volumes,
+				HostNetwork: true,
 			},
 		},
 	}
@@ -206,8 +206,8 @@ func (st *GlusterStorage) deployStorageClass(namespace string) error {
 	scname := "gluster.qm." + namespace
 
 	// Create storage class
-	storageclass := &kubestorage.StorageClass{
-		ObjectMeta: api.ObjectMeta{
+	storageclass := &storageclasspkg.StorageClass{
+		ObjectMeta: meta.ObjectMeta{
 			Name:      scname,
 			Namespace: namespace,
 			Labels: map[string]string{

--- a/pkg/storage/handler.go
+++ b/pkg/storage/handler.go
@@ -17,7 +17,7 @@ package storage
 import (
 	"github.com/coreos/quartermaster/pkg/spec"
 	"github.com/lpabon/godbc"
-	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 // StorageHandlerFuncs insulates the implementation from unsupported
@@ -29,7 +29,7 @@ type StorageHandlerFuncs struct {
 	UpdateClusterFunc func(old *spec.StorageCluster, new *spec.StorageCluster) error
 	DeleteClusterFunc func(c *spec.StorageCluster) error
 
-	MakeDeploymentFunc func(n *spec.StorageNode, old *extensions.Deployment) (*extensions.Deployment, error)
+	MakeDeploymentFunc func(n *spec.StorageNode, old *v1beta1.Deployment) (*v1beta1.Deployment, error)
 	AddNodeFunc        func(n *spec.StorageNode) (*spec.StorageNode, error)
 	UpdateNodeFunc     func(n *spec.StorageNode) (*spec.StorageNode, error)
 	DeleteNodeFunc     func(n *spec.StorageNode) error
@@ -61,7 +61,7 @@ func (s StorageHandlerFuncs) DeleteCluster(c *spec.StorageCluster) error {
 }
 
 func (s StorageHandlerFuncs) MakeDeployment(n *spec.StorageNode,
-	old *extensions.Deployment) (*extensions.Deployment, error) {
+	old *v1beta1.Deployment) (*v1beta1.Deployment, error) {
 	if s.MakeDeploymentFunc != nil {
 		return s.MakeDeploymentFunc(n, old)
 	}

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -17,9 +17,9 @@ package storage
 import (
 	"github.com/coreos/quartermaster/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/apis/extensions"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	restclient "k8s.io/client-go/rest"
 )
 
 type StorageClusterInterface interface {
@@ -55,7 +55,7 @@ type StorageNodeInterface interface {
 	// We use Deployments for now because they can handle rollouts and updates
 	// well.  We could deploy other object deployment types in the future like
 	// (StatefulSets, DaemonSets, etc).
-	MakeDeployment(s *spec.StorageNode, old *extensions.Deployment) (*extensions.Deployment, error)
+	MakeDeployment(s *spec.StorageNode, old *v1beta1.Deployment) (*v1beta1.Deployment, error)
 
 	// AddNode is called by Quartermaster when a deployment is Ready and is
 	// avaiable to be managed by the driver.  AddNode may save metadata on the
@@ -85,4 +85,4 @@ type StorageType interface {
 }
 
 // Registers driver with Quartermaster
-type StorageTypeNewFunc func(clientset.Interface, restclient.Interface) (StorageType, error)
+type StorageTypeNewFunc func(kubernetes.Interface, restclient.Interface) (StorageType, error)


### PR DESCRIPTION
Major change to Kubernetes where they pulled out their client
APIs into two repos: apimachinery, and client-go. This required
a lot of changes across the entire project, but will make it easier
in the future.